### PR TITLE
Dynamic multi-domain support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,11 @@ Safesecret is a Go-based web service for sharing sensitive information securely.
 
 ### Run the application
 ```bash
-# Build and run locally
+# Build and run locally (single domain)
 cd app && go build -o secrets && ./secrets --key=<SIGN_KEY> --domain=localhost --protocol=http
+
+# Build and run locally (multiple domains)
+cd app && go build -o secrets && ./secrets --key=<SIGN_KEY> --domains="localhost,127.0.0.1" --protocol=http
 
 # Run with Docker (development)
 docker-compose -f docker-compose-dev.yml up
@@ -112,7 +115,8 @@ Key configuration via environment variables or flags:
 - `MAX_EXPIRE` - Maximum message lifetime (default: 24h)
 - `PIN_SIZE` - PIN length in characters (default: 5)
 - `PIN_ATTEMPTS` - Max failed PIN attempts (default: 3)
-- `DOMAIN` - Service domain (required)
+- `DOMAINS` - Comma-separated list of allowed domains (e.g., "example.com,alt.example.com")
+- `DOMAIN` - Single domain (deprecated, use DOMAINS instead; kept for compatibility)
 - `PROTOCOL` - http or https (default: https)
 
 ## Testing Approach
@@ -155,9 +159,10 @@ Core libraries used:
 - Fonts: Google Fonts integration with preconnect optimization
 
 ### Local Development Configuration
-- Server requires explicit local config: `--domain=localhost:8080 --protocol=http`
+- Server requires explicit local config: `--domain=localhost:8080 --protocol=http` or `--domains=localhost:8080 --protocol=http`
 - Default protocol is HTTPS, must override for local development
-- Link generation uses configured domain/protocol for absolute URLs
+- Link generation uses request domain if allowed, falls back to first configured domain
+- Multiple domains supported via comma-separated list: `--domains="example.com,alt.example.com"`
 
 ## HTMX Implementation
 

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -24,7 +24,7 @@ import (
 
 // Config is a configuration for the server
 type Config struct {
-	Domain   string
+	Domains  []string // allowed domains list
 	WebRoot  string
 	Protocol string
 	Branding string


### PR DESCRIPTION
Replace static domain configuration with dynamic multi-domain support

Problem:
The service was configured with a single static domain (`DOMAIN` env var) used for generating
message links. When the service is hosted behind multiple domain aliases (e.g.,
secrets.example.com, secure.example.org), all generated links would use the configured static
domain regardless of which domain the user accessed the service through. This creates a poor user
experience and potential confusion.

Solution:
- Added multi-domain support: New `DOMAINS` environment variable accepts a comma-separated list of
allowed domains
- Dynamic link generation: Links now use the actual request domain when it's in the allowed
domains list
- Security validation: Request hosts are validated against the allowed domains list to prevent
domain spoofing
- Graceful fallback: If request domain is not allowed, falls back to the first configured domain
- Backward compatibility: Existing `DOMAIN` environment variable still works (marked as deprecated)

Security Features

- Prevents Host header injection attacks through domain validation
- Only allows links generation for explicitly configured domains
- Maintains URL security while enabling multi-domain functionality

Usage Examples

```sh
# Single domain (backward compatible)
./secrets --key=<KEY> --domain=example.com --protocol=https
```

```sh
# Multiple domains (new feature)
./secrets --key=<KEY> --domains="example.com,alt.example.com,secure.example.org" --protocol=https
```

```sh
# Environment variable
export DOMAINS="example.com,alt.example.com"
./secrets --key=<KEY> --protocol=https
```

Testing

- Added comprehensive test suite for domain validation logic
- Tests cover allowed/disallowed domains, port handling, and fallback behavior
- Updated existing tests to use new configuration structure
- All tests pass with 100% backward compatibility

Benefits

- ✅ Multi-domain support: Service works seamlessly across domain aliases
- ✅ Better UX: Links match the domain users are actually visiting
- ✅ Security: Prevents domain spoofing via Host header validation
- ✅ Backward compatible: Existing deployments continue to work unchanged
- ✅ Easy migration: Simple comma-separated list configuration

Breaking Changes

None. The `DOMAIN` environment variable continues to work as before, though it's now marked as
deprecated in favor of `DOMAINS`.
